### PR TITLE
Bundle high-churn chunks with the manifest

### DIFF
--- a/src/copier.rs
+++ b/src/copier.rs
@@ -1841,7 +1841,15 @@ impl CopierWorker {
             / PATROL_TOUCH_PERIOD.as_secs_f64())
         .clamp(0.0, 1.0);
         let tap_file = replication_buffer::construct_tapped_manifest_path(spool_path, source)?;
-        let (mut chunks, base) = parse_manifest_chunks(&tap_file, &targets.replication_targets)?;
+
+        // Get the chunks, but replace everything that's bundled with
+        // the manifest with a zero fingerprint: we don't have to
+        // fetch bundled chunks, just like zero chunks.
+        let (mut chunks, base) = parse_manifest_chunks(
+            &tap_file,
+            &targets.replication_targets,
+            crate::loader::zero_fingerprint(),
+        )?;
         let mut rng = rand::thread_rng();
 
         if let Some(base) = base.as_ref() {

--- a/src/tracker/snapshot_file_contents.rs
+++ b/src/tracker/snapshot_file_contents.rs
@@ -562,6 +562,7 @@ impl Tracker {
                 ctime_ns,
                 base_chunks_fprint: base_fprint.map(|fp| fp.into()),
                 chunks: compressible,
+                bundled_chunks: Vec::new(),
             }),
         };
 


### PR DESCRIPTION
Implements the improvement sketched in #7.

We already made manifests a lot smaller with #3, at the potential expense of one extra I/O. We can recover some of that by sending chunks we don't expect to benefit from deduplication (because they're rarely reused across transactions) inline with the manifest. The net effect will be similar data transfer, but fewer blobs. Combined with #3, we'll obtain lower transfer bandwidth, storage footprint, and API calls compared to v0.1.

The first chunk, the one that includes sqlite's header page, is a prime candidate: the header contains a 32-bit integer that's incremented whenever the file's contents change. The rest of the page serves as the root B-tree page for the schema table. Root pages are often extra sparse (only they get to hit < 50% occupancy), and the schema table is mostly SQL DDL, i.e., nicely compressible. Once compressed by zstd, it shouldn't add too much to the manifest's size.