### PR TITLE
Let snapshots load chunks on demand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ lru = { version = "0.7", default-features = false }  # Disable hashbrown
 memmap2 = "0.5"
 percent-encoding = "2"
 prost = "0.9"
+quinine = "0.2"
 rand = "0.8"
 rayon = "1.5"
 regex = "1"

--- a/examples/verneuilctl.rs
+++ b/examples/verneuilctl.rs
@@ -166,7 +166,11 @@ fn restore(cmd: Restore, config: Options) -> Result<()> {
         None,
         &cmd.manifest,
     )?;
-    let snapshot = verneuil::Snapshot::new_with_default_targets(&manifest, base)?;
+    let snapshot = verneuil::Snapshot::new_with_default_targets(
+        verneuil::SnapshotLoadingPolicy::Eager,
+        &manifest,
+        base,
+    )?;
     let reader = snapshot.as_read(0, u64::MAX)?; // Read the whole thing.
     output_reader(reader, &cmd.out)
 }

--- a/examples/verneuilctl.rs
+++ b/examples/verneuilctl.rs
@@ -167,7 +167,7 @@ fn restore(cmd: Restore, config: Options) -> Result<()> {
         &cmd.manifest,
     )?;
     let snapshot = verneuil::Snapshot::new_with_default_targets(&manifest, base)?;
-    let reader = snapshot.as_read(0, u64::MAX); // Read the whole thing.
+    let reader = snapshot.as_read(0, u64::MAX)?; // Read the whole thing.
     output_reader(reader, &cmd.out)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub use manifest_schema::Manifest;
 pub use replication_buffer::manifest_name_for_hostname_path;
 pub use result::Result;
 pub use snapshot::Snapshot;
+pub use snapshot::SnapshotLoadingPolicy;
 
 /// Read the verneuil configuration from this variable by default.
 pub const VERNEUIL_CONFIG_ENV_VAR: &str = "VERNEUIL_CONFIG";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,10 @@ pub struct Options {
     pub replication_spooling_dir_permissions: Option<u32>,
 
     /// List of default replication targets.
-    #[serde(default)]
     pub replication_targets: Vec<replication_target::ReplicationTarget>,
+
+    /// Global policy when loading snapshot data.
+    pub snapshot_loading_policy: SnapshotLoadingPolicy,
 }
 
 #[repr(C)]
@@ -150,6 +152,7 @@ pub fn configure_replication(options: Options) -> Result<()> {
     }
 
     replication_target::set_default_replication_targets(options.replication_targets);
+    snapshot::set_default_snapshot_loading_policy(options.snapshot_loading_policy);
 
     Ok(())
 }

--- a/src/snapshot_vfs_ops.rs
+++ b/src/snapshot_vfs_ops.rs
@@ -458,7 +458,7 @@ impl SnapshotFile {
             .ok_or_else(|| fresh_error!("attempted to read uninitialised SnapshotFile"))?
             .data;
 
-        let copied = std::io::copy(&mut snapshot.as_read(offset, dst.len() as u64), &mut dst)
+        let copied = std::io::copy(&mut snapshot.as_read(offset, dst.len() as u64)?, &mut dst)
             .map_err(|e| chain_error!(e, "failed to read from snapshot"))?;
         dst.fill(0);
         Ok(copied)

--- a/src/snapshot_vfs_ops.rs
+++ b/src/snapshot_vfs_ops.rs
@@ -17,6 +17,7 @@ use crate::sqlite_code::SqliteCode;
 use crate::sqlite_lock_level::LockLevel;
 use crate::Result;
 use crate::Snapshot;
+use crate::SnapshotLoadingPolicy;
 
 /// Number of background refresh workers.
 const REFRESH_POOL_SIZE: usize = 4;
@@ -167,7 +168,7 @@ fn fetch_new_data(path: String) -> Result<Arc<Data>> {
         ctime,
         ctime_ns,
         reload_queued: AtomicBool::new(false),
-        data: Snapshot::new_with_default_targets(&manifest, base)?,
+        data: Snapshot::new_with_default_targets(SnapshotLoadingPolicy::Default, &manifest, base)?,
     });
 
     LIVE_DATA

--- a/src/tracker/invariants.rs
+++ b/src/tracker/invariants.rs
@@ -59,12 +59,9 @@ impl Tracker {
         cache_builder
     }
 
-    fn fetch_snapshot_or_die(
-        &self,
-        manifest: &Manifest,
-        source: ChunkSource,
-    ) -> crate::snapshot::Snapshot {
-        crate::snapshot::Snapshot::new(
+    fn fetch_snapshot_or_die(&self, manifest: &Manifest, source: ChunkSource) -> crate::Snapshot {
+        crate::Snapshot::new(
+            crate::SnapshotLoadingPolicy::Default,
             self.cache_builder_for_source(source),
             &self.replication_targets.replication_targets,
             manifest,

--- a/src/tracker/invariants.rs
+++ b/src/tracker/invariants.rs
@@ -199,7 +199,13 @@ impl Tracker {
         );
 
         let snapshot = self.fetch_snapshot_or_die(&manifest, ChunkSource::Staged);
-        std::io::copy(&mut snapshot.as_read(0, u64::MAX), &mut hasher).expect("should hash");
+        std::io::copy(
+            &mut snapshot
+                .as_read(0, u64::MAX)
+                .expect("as_read should succeed"),
+            &mut hasher,
+        )
+        .expect("should hash");
         assert_eq!(expected, hasher.finalize());
         Ok(())
     }


### PR DESCRIPTION
When a snapshot is small (maybe < 10-20 chunks, < 2 MB), it makes sense to download everything as soon as the snapshot is created. Snapshots for larger databases (e.g., 100+ MB) may not need to load all that data. Add the option to load only a prefix of the database (where we expect all b-tree root and internal pages to live) on snapshot creation, and the rest on demand.

The current implementation fetches only one chunk at a time, with no prefaulting, so it will be slow. We can fix that later. For now, it's on-demand loading is disabled by default and available when it makes sense.

Closes #12.