### PR TITLE
zstd 0.10 -> 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ tracing-subscriber = { version = "0.3", optional = true, features = ["tracing-lo
 uluru = "3"
 umash = "0.4"
 uuid = { version = "0.8", features = ["v4"] }
-zstd = "0.10"
+zstd = "0.11"
 
 [dev-dependencies]
 rusqlite = { version = "0.26" }  # For the sample rusqlite_integration.


### PR DESCRIPTION
Bumping zstd to 0.11. Reading the change log for zstd 0.11, it doesn't look like there should be any breaking changes.
I ran `cargo test` and things looked good too.

Please let me know if there's anything else I can do!