### PR TITLE
process_id: improve fallback path when process birth time is missing

### DIFF
--- a/src/atomic_kv32.rs
+++ b/src/atomic_kv32.rs
@@ -1,0 +1,117 @@
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+/// An AtomicKV32 is an atomically-updatable pair of two u32s:
+/// a key and a value.
+///
+/// When the key changes, an AtomicKV32 lets the *last* write win,
+/// but, otherwise, the *first* write wins for a series of updates
+/// with the same key (and potentially different values).
+pub(crate) struct AtomicKV32 {
+    // The low half is the key, high half the value.
+    value: AtomicU64,
+}
+
+impl AtomicKV32 {
+    /// Creates a fresh AtomicKV32 with this key and value.
+    pub const fn new(key: u32, value: u32) -> AtomicKV32 {
+        AtomicKV32 {
+            value: AtomicU64::new(Self::encode(key, value)),
+        }
+    }
+
+    /// Returns the current key-value pair stored in this `AtomicKV32`.
+    ///
+    /// The first element of the tuple is the key, the second the value.
+    pub fn get(&self) -> (u32, u32) {
+        // Acquire matches the compare_exchange in `set`.
+        Self::decode(self.value.load(Ordering::Acquire))
+    }
+
+    /// Updates this `AtomicKV32`'s contents to the key/value pair,
+    /// unless the current contents' key is identical.
+    ///
+    /// Returns the potentially updated contents on exit.
+    pub fn set(&self, key: u32, value: u32) -> (u32, u32) {
+        let update = Self::encode(key, value);
+
+        // Acquire matches the compare_exchange below
+        let mut current = self.value.load(Ordering::Acquire);
+        while Self::decode(current).0 != key {
+            // The ordering here is stronger than necessary, but we
+            // only call `set()` about once per process.
+            match self
+                .value
+                .compare_exchange(current, update, Ordering::SeqCst, Ordering::SeqCst)
+            {
+                Ok(_prev) => current = update, // success!
+                Err(actual) => current = actual,
+            }
+        }
+
+        Self::decode(current)
+    }
+
+    /// Packs a key-value pair in a u64.
+    const fn encode(key: u32, value: u32) -> u64 {
+        // Stick the key in the low half for easier extraction.
+        ((value as u64) << 32) | (key as u64)
+    }
+
+    /// Unpacks a u64 into a key-value pair.
+    const fn decode(bits: u64) -> (u32, u32) {
+        (bits as u32, (bits >> 32) as u32)
+    }
+}
+
+#[test]
+fn test_encode_decode() {
+    let ints = [0, 1, 2, 3, 1000, u32::MAX - 2, u32::MAX - 1, u32::MAX];
+
+    for key in ints {
+        for value in ints {
+            assert_eq!(
+                AtomicKV32::decode(AtomicKV32::encode(key, value)),
+                (key, value)
+            );
+        }
+    }
+}
+
+#[test]
+fn test_init() {
+    let ints = [0, 1, 2, 3, 1000, u32::MAX - 2, u32::MAX - 1, u32::MAX];
+
+    for key in ints {
+        for value in ints {
+            let pair = AtomicKV32::new(key, value);
+
+            assert_eq!(pair.get(), (key, value));
+
+            // Make sure we can update it.
+            pair.set(42, 1234);
+            assert_eq!(pair.get(), (42u32, 1234u32));
+        }
+    }
+}
+
+#[test]
+fn test_set() {
+    let pair = AtomicKV32::new(0, 0);
+
+    // Same key -> should no-op
+    pair.set(0, 42);
+    assert_eq!(pair.get(), (0u32, 0u32));
+
+    // Different key -> should succeed
+    assert_eq!(pair.set(1000, u32::MAX), (1000u32, u32::MAX));
+    assert_eq!(pair.get(), (1000u32, u32::MAX));
+
+    // Same key -> should no-op
+    assert_eq!(pair.set(1000, 0), (1000u32, u32::MAX));
+    assert_eq!(pair.get(), (1000u32, u32::MAX));
+
+    // Different key -> should succeed
+    pair.set(0, 42);
+    assert_eq!(pair.get(), (0u32, 42u32));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod atomic_kv32;
 mod copier;
 mod executor;
 mod instance_id;


### PR DESCRIPTION
We want to disambiguate pids to avoid collisions when pids are recycled. Some OSes have explicit support for unique pids, but that's not super widespread, so we fake it by augmenting the pid with the process's birth timestamp (with arbitrary units and epoch).

Unfortunately, it seems that Darwin now only exposes btime (or its native unique process identifier) to privileged processes, so we have to improve the fallback logic.

The old implementation simply substituted the constant `u64::MAX` for the btime when it was missing.  The new implementation generates a random u32.

Of course, this means the "btime" associated with a given process may not vary.  That's why this commit introduces AtomicKV32, an atomic register for key-value pairs of u32, where Last Write Wins when the key changes, but First Write Wins when the key doesn't.

The process_id module uses this AtomicKV32 to associate a consistent btime to a pid, while still updating the `(pid, btime-or-random-u32)` pair when the pid changes (after fork).

The value must be a u32, so we now also truncate the btime, when we have one, to 32 bits.  That's enough to disambiguate pids.

While we're working on !Linux platforms, only try to get the btime for pid 1 on Linux.  Also, add a test for space in the middle of comm, to show that our regex that already handled newlines can also do spaces.