### PR TITLE
Port file_ops.c to OS X

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,9 @@ zstd = "0.11"
 [dev-dependencies]
 rusqlite = { version = "0.26" }  # For the sample rusqlite_integration.
 tracing-subscriber = { version = "0.3", features = ["env-filter", "tracing-log"] }  # Examples set up tracing.
+
 clap = { version = "3", features = ["derive"] }
+test_dir = "0.2"
 
 [build-dependencies]
 cc = "1"

--- a/c/file_ops.c
+++ b/c/file_ops.c
@@ -13,7 +13,12 @@ verneuil__getxattr(int fd, const char *name, void *buf, size_t bufsz)
         ssize_t ret;
 
         do {
+#ifdef __APPLE__
+                ret = fgetxattr(fd, name, buf, bufsz, /*position=*/0, /*options=*/0);
+#else
+                /* Assume this is linux-compatible. */
                 ret = fgetxattr(fd, name, buf, bufsz);
+#endif
         } while (ret < 0 && errno == EINTR);
 
         if (ret >= 0)
@@ -31,7 +36,11 @@ verneuil__setxattr(int fd, const char *name, const void *buf, size_t bufsz)
         ssize_t ret;
 
         do {
+#ifdef __APPLE__
+                ret = fsetxattr(fd, name, buf, bufsz, /*position=*/0, /*options=*/0);
+#else
                 ret = fsetxattr(fd, name, buf, bufsz, /*flags=*/0);
+#endif
         } while (ret < 0 && errno == EINTR);
 
         if (ret == 0)


### PR DESCRIPTION
First add unit tests for the version xattr tagging machinery, then tweak `verneuil__{get,set}xattr` for Darwin-style `f{get,set}xattr`.

Passes unit tests on darwin/arm64 and linux/amd64.