### PR TITLE
Support OS X

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -100,9 +100,10 @@ fn main() {
         build.define("SQLITE_CORE", None);
     }
 
+    // We want GNU extensions on Linux.
+    #[cfg(target_os = "linux")]
+    build.define("_GNU_SOURCE", None);
     build
-        // We want GNU extensions.
-        .define("_GNU_SOURCE", None)
         // We know the linuxvfs doesn't implement dirsync.
         .define("SQLITE_DISABLE_DIRSYNC", None)
         .file("c/file_ops.c")

--- a/c/linuxvfs.c
+++ b/c/linuxvfs.c
@@ -1334,9 +1334,40 @@ linux_file_sync(sqlite3_file *vfile, int flags)
         if (file->path == NULL)
                 return SQLITE_OK;
 
+#ifdef __APPLE__
         do {
-                r = fdatasync(file->fd);
+                /*
+                 * Per
+                 * https://developer.apple.com/documentation/xcode/reducing-disk-writes#Minimize-explicit-storage-synchronization,
+                 * Apple devices usually want F_BARRIERFSYNC (fsync +
+                 * barrier), while F_FULLFSYNC is the working fsync
+                 * (flushes the storage device's volatile cache).
+                 *
+                 * In either case, we won't corrupt data (unlike plain
+                 * fsync, in case of power failure?), but
+                 * F_BARRIERFSYNC may lose transactions committed to
+                 * the kernel but not yet persisted.
+                 *
+                 * Set `PRAGMA fullfsync = on` for F_FULLSYNC.
+                 */
+                int request = ((flags & 0x0F) == SQLITE_SYNC_FULL)
+                        ? F_FULLFSYNC
+                        : F_BARRIERFSYNC;
+                r = fcntl(file->fd, request, 0);
         } while (r != 0 && errno == EINTR);
+#else
+        r = -1;
+#endif
+
+        /*
+         * The regular fdatasync path also handles any error in the
+         * Apple-specific fcntl code.
+         */
+        if (r != 0) {
+                do {
+                        r = fdatasync(file->fd);
+                } while (r != 0 && errno == EINTR);
+        }
 
         if (r != 0) {
                 switch (errno) {

--- a/c/linuxvfs.c
+++ b/c/linuxvfs.c
@@ -1,5 +1,13 @@
 #include "linuxvfs.h"
 
+#ifdef __APPLE__
+/*
+ * Some SQLite sources like to unconditionally define _GNU_SOURCE,
+ * but that only makes sense for glibc.
+ */
+# undef _GNU_SOURCE
+#endif
+
 #include <assert.h>
 #include <dlfcn.h>
 #include <errno.h>

--- a/c/linuxvfs.c
+++ b/c/linuxvfs.c
@@ -1360,7 +1360,13 @@ now_ms_boottime(void)
 {
         struct timespec now;
 
-        clock_gettime(CLOCK_BOOTTIME, &now);
+#ifdef __APPLE__
+        const clockid_t clock = CLOCK_UPTIME_RAW;
+#else
+        const clockid_t clock = CLOCK_BOOTTIME;
+#endif
+
+        clock_gettime(clock, &now);
         return 1000 * (uint64_t)now.tv_sec + (now.tv_nsec / 1000000);
 }
 

--- a/c/linuxvfs.c
+++ b/c/linuxvfs.c
@@ -70,6 +70,13 @@ SQLITE_EXTENSION_INIT1
 # define SQLITE_TEMP_FILE_PREFIX "etilqs_"
 #endif
 
+#ifndef O_LARGEFILE
+/*
+ * This is a no-op flag on 64-bit builds; we keep it to match sqlite.
+ */
+# define O_LARGEFILE 0
+#endif
+
 /**
  * Some older distributions fail to expose these constants.  Hardcode
  * them if necessary: open file description locks have been around

--- a/c/linuxvfs.c
+++ b/c/linuxvfs.c
@@ -1877,18 +1877,17 @@ linux_file_control(sqlite3_file *vfile, int op, void *arg)
 static int
 linux_file_sector_size(sqlite3_file *vfile)
 {
-        enum {
-                /*
-                 * sqlite assumes the sector size is a multiple of its
-                 * min value, 512 bytes.
-                 */
-                MIN_SECTOR_SIZE = 512,
+        /*
+         * sqlite assumes the sector size is a multiple of its min
+         * value, 512 bytes.
+         */
+        const size_t min_sector_size = 512;
 #ifdef PAGE_SIZE
-                DEFAULT_SECTOR_SIZE = PAGE_SIZE,
+        const size_t default_sector_size = PAGE_SIZE;
 #else
-                DEFAULT_SECTOR_SIZE = 4096,
+        const size_t default_sector_size = 4096;
 #endif
-        };
+
         static atomic_int cached_sector_size = 0;
         long sector_size;
 
@@ -1915,10 +1914,10 @@ linux_file_sector_size(sqlite3_file *vfile)
          */
         sector_size = sysconf(_SC_PAGESIZE);
         if (sector_size <= 0 || sector_size > INT_MAX)
-                sector_size = DEFAULT_SECTOR_SIZE;
+                sector_size = default_sector_size;
 
-        if ((sector_size % MIN_SECTOR_SIZE) != 0)
-                sector_size = MIN_SECTOR_SIZE;
+        if ((sector_size % min_sector_size) != 0)
+                sector_size = min_sector_size;
 
         atomic_store_explicit(&cached_sector_size, sector_size,
             memory_order_relaxed);

--- a/c/linuxvfs.c
+++ b/c/linuxvfs.c
@@ -490,41 +490,69 @@ linux_open(sqlite3_vfs *vfs, const char *name, sqlite3_file *vfile,
          */
         if (name == NULL || (flags & SQLITE_OPEN_DELETEONCLOSE) != 0) {
                 const char *base;
+                /* Non-null if there's something to unlink there. */
+                char *temp_path = NULL;
+                int r;
+                bool use_fallback;
 
                 base = get_tempdir_base();
 
                 file->path = NULL;
+#ifdef O_TMPFILE
                 fd = linux_safe_open(base, O_TMPFILE | O_EXCL | open_flags, 0600);
+                use_fallback = fd < 0 && errno == EOPNOTSUPP;
+#else
+                fd = -1;
+                use_fallback = true;
+#endif
+                /*
+                 * Some OSes and filesystems do not support O_TMPFILE.
+                 * Try a minimalistic mkstemp-based fallback.
+                 */
+                if (use_fallback)
+                        errno = EINTR;
+
+                while (use_fallback && fd < 0 && errno == EINTR) {
+                        if (asprintf(&temp_path, "%s/verneuil.XXXXXX", base) < 0) {
+                                rc = SQLITE_CANTOPEN;
+                                goto fail;
+                        }
+
+                        fd = mkostemp(temp_path, O_CLOEXEC | O_LARGEFILE);
+                        if (fd < 0) {
+                                int err = errno;
+
+                                free(temp_path);
+                                temp_path = NULL;
+                                errno = err;
+                        }
+                }
 
                 if (fd < 0 && errno == EACCES) {
                         rc = SQLITE_READONLY_DIRECTORY;
                         goto fail;
                 }
 
-                /*
-                 * Some filesystems do not support O_TMPFILE.  Try a
-                 * minimalistic mkstemp-based fallback.  If anything
-                 * goes wrong, propagate the EOPNOTSUPP error: we
-                 * don't really care too much about such filesystems.
-                 */
-                if (fd < 0 && errno == EOPNOTSUPP) {
-                        char *path;
+                if (fd < 0) {
+                        rc = SQLITE_CANTOPEN;
+                        goto fail;
+                }
 
-                        if (asprintf(&path, "%s/verneuil.XXXXXX", base) < 0) {
-                                rc = SQLITE_CANTOPEN_NOTEMPDIR;
-                                goto fail;
-                        }
+                if (temp_path != NULL) {
+                        do {
+                                r = unlink(temp_path);
+                        } while (r != 0 && errno == EINTR);
+                        /*
+                         * Unclear what to do with errors; SQLite
+                         * doesn't handle any...
+                         */
+                }
 
-                        fd = mkostemp(path, O_CLOEXEC | O_LARGEFILE);
-                        if (fd >= 0)
-                                (void)unlink(path);
-
-                        free(path);
-                        fd = linux_ensure_high_fd(fd);
-                        if (fd < 0) {
-                                rc = SQLITE_CANTOPEN_NOTEMPDIR;
-                                goto fail;
-                        }
+                free(temp_path);
+                fd = linux_ensure_high_fd(fd);
+                if (fd < 0) {
+                        rc = SQLITE_CANTOPEN;
+                        goto fail;
                 }
         } else {
                 if ((flags & SQLITE_OPEN_CREATE) != 0)

--- a/c/linuxvfs.c
+++ b/c/linuxvfs.c
@@ -6,6 +6,11 @@
  * but that only makes sense for glibc.
  */
 # undef _GNU_SOURCE
+/*
+ * If someone ever manages to #include a version of `fcntl.h` with the
+ * #ifdef PRIVATE definitions, we'll be able to detect mismatches.
+ */
+# define PRIVATE
 #endif
 
 #include <assert.h>
@@ -77,20 +82,39 @@ SQLITE_EXTENSION_INIT1
 # define O_LARGEFILE 0
 #endif
 
+#ifdef __linux__
 /**
  * Some older distributions fail to expose these constants.  Hardcode
  * them if necessary: open file description locks have been around
  * since Linux 3.15, and we don't try to support anything that old
  * (getrandom was introduced in 3.17, and we also use that).
  */
-#ifndef F_OFD_GETLK
-#define F_OFD_GETLK     36
-#define F_OFD_SETLK     37
-#define F_OFD_SETLKW    38
+# ifndef F_OFD_GETLK
+#  define F_OFD_GETLK     36
+#  define F_OFD_SETLK     37
+#  define F_OFD_SETLKW    38
+# endif
+
+# if (F_OFD_GETLK != 36) || (F_OFD_SETLK != 37) || (F_OFD_SETLKW != 38)
+#  error "Mismatch in fallback OFD fcntl constants."
+# endif
 #endif
 
-#if (F_OFD_GETLK != 36) || (F_OFD_SETLK != 37) || (F_OFD_SETLKW != 38)
-# error "Mismatch in fallback OFD fcntl constants."
+#ifdef __APPLE__
+# ifndef F_OFD_GETLK
+/*
+ * Copy fallback definitions from
+ * https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/bsd/sys/fcntl.h#L360-L363
+ */
+#  define F_OFD_SETLK             90
+#  define F_OFD_SETLKW            91
+#  define F_OFD_GETLK             92
+# endif
+
+/* On the off chance someone builds with a full fcntl.h */
+# if (F_OFD_SETLK != 90) || (F_OFD_SETLKW != 91) || (F_OFD_GETLK != 92)
+#  error "Unexpected drift in private OFD fcntl constants for darwin."
+# endif
 #endif
 
 struct linux_file {

--- a/c/vfs.c
+++ b/c/vfs.c
@@ -121,8 +121,14 @@ struct linux_file {
         /*
          * This metadata identifies the inode that `fd` refers to.
          */
-        dev_t device;
-        ino_t inode;
+        union {
+                dev_t device;
+                uint64_t rust_padding_for_device;
+        };
+        union {
+                ino_t inode;
+                uint64_t rust_padding_for_inode;
+        };
 
         /*
          * The Rust-side's change tracking state.
@@ -164,11 +170,11 @@ struct linux_file {
 static_assert(sizeof(struct sqlite3_file) == sizeof(void *),
     "vfs_ops.rs assumes sqlite3_file consists of one vtable pointer.");
 
-static_assert(sizeof(dev_t) == sizeof(uint64_t),
-    "vfs_ops.rs assumes dev_t as a u64.");
+static_assert(sizeof(dev_t) <= sizeof(uint64_t),
+    "vfs_ops.rs assumes dev_t fits in a u64.");
 
-static_assert(sizeof(ino_t) == sizeof(uint64_t),
-    "vfs_ops.rs assumes ino_t as a u64.");
+static_assert(sizeof(ino_t) <= sizeof(uint64_t),
+    "vfs_ops.rs assumes ino_t fits in a u64.");
 
 struct snapshot_file {
         sqlite3_file base;

--- a/c/vfs.c
+++ b/c/vfs.c
@@ -1,6 +1,14 @@
 #include "verneuil.h"
 #include "vfs.h"
 
+#ifdef __APPLE__
+/*
+ * Some SQLite sources like to unconditionally define _GNU_SOURCE,
+ * but that only makes sense for glibc.
+ */
+# undef _GNU_SOURCE
+#endif
+
 #include <assert.h>
 #include <dlfcn.h>
 #include <errno.h>

--- a/c/vfs.c
+++ b/c/vfs.c
@@ -1604,7 +1604,13 @@ now_ms_boottime(void)
 {
         struct timespec now;
 
-        clock_gettime(CLOCK_BOOTTIME, &now);
+#ifdef __APPLE__
+        const clockid_t clock = CLOCK_UPTIME_RAW;
+#else
+        const clockid_t clock = CLOCK_BOOTTIME;
+#endif
+
+        clock_gettime(clock, &now);
         return 1000 * (uint64_t)now.tv_sec + (now.tv_nsec / 1000000);
 }
 

--- a/c/vfs.c
+++ b/c/vfs.c
@@ -1265,16 +1265,27 @@ linux_dlclose(sqlite3_vfs *vfs, void *handle)
         return;
 }
 
+#ifdef __APPLE__
+static ssize_t
+getrandom_compat(void *buf, size_t buflen)
+{
+        /* arc4random doesn't fail. */
+        arc4random_buf(buf, buflen);
+        return buflen;
+}
+#else
 /*
  * Linux added the getrandom syscall in 3.17, but glibc only recently
  * added a wrapper.  Define our own getrandom.
  */
 static ssize_t
-getrandom_compat(void *buf, size_t buflen, unsigned int flags)
+getrandom_compat(void *buf, size_t buflen)
 {
+        unsigned int flags = 0;
 
         return syscall(SYS_getrandom, buf, buflen, flags);
 }
+#endif
 
 static int
 linux_randomness(sqlite3_vfs *vfs, int n, char *dst)
@@ -1292,7 +1303,7 @@ linux_randomness(sqlite3_vfs *vfs, int n, char *dst)
                  * (256-byte) seed, so we don't have to worry
                  * about short reads.
                  */
-                r = getrandom_compat(dst, n, /*flags=*/0);
+                r = getrandom_compat(dst, n);
         } while (r < 0 && errno == EINTR);
         /*
          * It's ok to fail silently: we zero-filled, so no UB,
@@ -2093,7 +2104,7 @@ linux_tempfilename(char **dst)
 
         clock_gettime(CLOCK_REALTIME, &now);
         do {
-                r = getrandom_compat(noise, sizeof(noise), 0);
+                r = getrandom_compat(noise, sizeof(noise));
         } while (r <= 0 && errno == EINTR);
 
         unique = atomic_fetch_add(&counter, 1);

--- a/c/vfs.c
+++ b/c/vfs.c
@@ -61,6 +61,13 @@ SQLITE_EXTENSION_INIT1
 # define SQLITE_TEMP_FILE_PREFIX "etilqs_"
 #endif
 
+#ifndef O_LARGEFILE
+/*
+ * This is a no-op flag on 64-bit builds; we keep it to match sqlite.
+ */
+# define O_LARGEFILE 0
+#endif
+
 /**
  * Some older distributions fail to expose these constants.  Hardcode
  * them if necessary: open file description locks have been around


### PR DESCRIPTION
Mostly small changes to the C code, and trying to work with the few sysctls the folks over at Cupertino still let unprivileged mortals use. I want to call out the 64 bit dev/ino -> 32 bit in the VFS code (that struct is also accessed from Rust), the !O_TMPFILE fallback code path (now the main code path for temporary files on OS X), and the topmost datasync commit.

The OFD locks with "private" fcntl number are fun, but overall feel unlikely to break.