### PR TITLE
t/test.sh: make it work with rootless podman (behind the docker skin)

### DIFF
--- a/t/test.sh
+++ b/t/test.sh
@@ -75,6 +75,14 @@ trap cleanup EXIT
 mkdir -p minio
 rm -rf minio/*
 
+# We use minio to spin up a local s3-compatible service on localhost:7777
+#
+# The data files in the data volume aren't as simple as they once were; the
+# easiest way to see what's stored in the local buckets is probably
+#
+# $ docker run --security-opt label=disable -v ./escape-hatch:/out --net=host -it --entrypoint=/bin/sh docker.io/minio/mc
+# sh-5.1# mc alias set verneuil http://localhost:7777 VERNEUIL_TEST_ACCOUNT VERNEUIL_TEST_KEY
+# sh-5.1# mc ls verneuil  # etc.
 EXTRA_DOCKER_ARGS=${EXTRA_DOCKER_ARGS:-}
 if docker info | grep -q 'rootless: true' ; then
     # rootless, no need for fancy user mapping, and also can't assume
@@ -98,6 +106,9 @@ docker run --net=host $EXTRA_DOCKER_ARGS \
   -e "MINIO_ROOT_PASSWORD=VERNEUIL_TEST_KEY" \
   docker.io/minio/minio server --address 127.0.0.1:7777  /data &
 
+# Leftover state shouldn't result in incorrect replication, but does trigger extra assertions
+# that assume a clean initial state.
+echo "About to run integration tests. Remember to clear leftover state under '/tmp/verneuil-*' if running with extra (read) validation."
 sleep 5;
 
 OFFLINE_CONFIG=$(cat <<'EOF'

--- a/t/test.sh
+++ b/t/test.sh
@@ -73,8 +73,7 @@ cleanup
 trap cleanup EXIT
 
 mkdir -p minio
-rm -rf minio
-mkdir -p minio
+rm -rf minio/*
 
 EXTRA_DOCKER_ARGS=${EXTRA_DOCKER_ARGS:-}
 if docker info | grep -q 'rootless: true' ; then


### PR DESCRIPTION
The main differences are:

1. we *must* specify the whole path, with the docker.io prefix
2. rootless writes actually appear as writes to the current user outside the pid namespace.  This means that the id mapping trick is not only unnecessary, but in fact doesn't work at all because #security.