### PR TITLE
Let writers specify the chunk size they want

### DIFF
--- a/src/copier.rs
+++ b/src/copier.rs
@@ -208,7 +208,7 @@ const FAST_COMPRESSION_LEVEL: i32 = 1;
 /// When the raw data is at least this large, convert default (0)
 /// compression to `FAST_COMPRESSION_LEVEL`: we assume that's not
 /// sqlite db data, and probably incompressible.
-const FAST_COMPRESSION_AUTO_SIZE: usize = (crate::tracker::SNAPSHOT_GRANULARITY as usize) + 1;
+const FAST_COMPRESSION_AUTO_SIZE: usize = (crate::tracker::WRITE_SNAPSHOT_GRANULARITY as usize) + 1;
 
 lazy_static::lazy_static! {
     static ref RECENT_WORK: Mutex<RecentWorkSet> = Mutex::new(RecentWorkSet::new(COPY_REQUEST_MEMORY, COPY_REQUEST_JITTER));

--- a/src/copier.rs
+++ b/src/copier.rs
@@ -205,10 +205,13 @@ const CHUNK_COMPRESSION_LEVEL: i32 = 0;
 /// long spans of trivially compressible 0s.
 const FAST_COMPRESSION_LEVEL: i32 = 1;
 
-/// When the raw data is at least this large, convert default (0)
+/// When the raw data is *more than* this large, convert default (0)
 /// compression to `FAST_COMPRESSION_LEVEL`: we assume that's not
 /// sqlite db data, and probably incompressible.
-const FAST_COMPRESSION_AUTO_SIZE: usize = (crate::tracker::WRITE_SNAPSHOT_GRANULARITY as usize) + 1;
+fn fast_compression_auto_limit() -> usize {
+    crate::tracker::DEFAULT_WRITE_SNAPSHOT_GRANULARITY
+        .max(crate::tracker::write_snapshot_granularity()) as usize
+}
 
 lazy_static::lazy_static! {
     static ref RECENT_WORK: Mutex<RecentWorkSet> = Mutex::new(RecentWorkSet::new(COPY_REQUEST_MEMORY, COPY_REQUEST_JITTER));
@@ -840,7 +843,7 @@ async fn copy_file(
         // maximum we expect for a db chunk, assume it's probably
         // fingerprints (incompressible), and override that by telling
         // zstd to optimise for speed over quality.
-        let level = if level == 0 && bytes.len() >= FAST_COMPRESSION_AUTO_SIZE {
+        let level = if level == 0 && bytes.len() > fast_compression_auto_limit() {
             FAST_COMPRESSION_LEVEL
         } else {
             level

--- a/src/manifest_schema.rs
+++ b/src/manifest_schema.rs
@@ -92,6 +92,10 @@ pub struct BundledChunk {
     pub chunk_data: Vec<u8>,
 }
 
+/// We assume manifests snapshotted db files in 64 KB chunks when
+/// the manifest doesn't specify `base_chunk_size`.
+pub const DEFAULT_BASE_CHUNK_SIZE: u64 = 1 << 16;
+
 #[derive(Clone, PartialEq, Eq, prost::Message)]
 pub struct ManifestV1 {
     // The fingerprint for the file's 100-byte sqlite header.  There
@@ -173,6 +177,12 @@ pub struct ManifestV1 {
     // the content-addressed store.
     #[prost(message, repeated, tag = "16")]
     pub bundled_chunks: Vec<BundledChunk>,
+
+    // Default chunk size for this manifest.  All but the last chunk
+    // must have this size if provided.  Defaults to
+    // `DEFAULT_BASE_CHUNK_SIZE` when missing.
+    #[prost(uint64, optional, tag = "10")]
+    pub base_chunk_size: Option<u64>,
 }
 
 /// When deserialising a `Manifest`, it usually makes sense to use
@@ -794,6 +804,7 @@ fn test_manifest_v1_default() {
         generated_by: vec![],
         chunks: vec![],
         bundled_chunks: vec![],
+        base_chunk_size: None,
     };
 
     let empty: &[u8] = b"";

--- a/src/tracker/snapshot_file_contents.rs
+++ b/src/tracker/snapshot_file_contents.rs
@@ -28,7 +28,7 @@ use crate::result::Result;
 use super::MutationState;
 use super::Tracker;
 use super::BASE_CHUNK_MIN_LENGTH;
-use super::SNAPSHOT_GRANULARITY;
+use super::WRITE_SNAPSHOT_GRANULARITY;
 
 /// What should we do with the current base chunk fingerprint list?
 enum BaseChunkAction {
@@ -374,8 +374,8 @@ impl Tracker {
             .metadata()
             .map_err(|e| chain_error!(e, "failed to stat file", ?self.path))?
             .len();
-        let num_chunks = len / SNAPSHOT_GRANULARITY
-            + (if (len % SNAPSHOT_GRANULARITY) > 0 {
+        let num_chunks = len / WRITE_SNAPSHOT_GRANULARITY
+            + (if (len % WRITE_SNAPSHOT_GRANULARITY) > 0 {
                 1
             } else {
                 0
@@ -398,7 +398,7 @@ impl Tracker {
             let grown = (fprints.len() as u64) < num_chunks;
             let wrote_past_end = self
                 .dirty_chunks
-                .range(fprints.len() as u64 * SNAPSHOT_GRANULARITY..=u64::MAX)
+                .range(fprints.len() as u64 * WRITE_SNAPSHOT_GRANULARITY..=u64::MAX)
                 .next()
                 .is_some();
             let delta = (grown || wrote_past_end) as u64;
@@ -419,7 +419,7 @@ impl Tracker {
         chunk_fprints.resize(num_chunks as usize, Fingerprint::new(0, 0));
 
         // Box this allocation to avoid a 64KB stack allocation.
-        let mut buf = Box::new([0u8; SNAPSHOT_GRANULARITY as usize]);
+        let mut buf = Box::new([0u8; WRITE_SNAPSHOT_GRANULARITY as usize]);
 
         let mut num_snapshotted: usize = 0;
         let mut bundled_chunks = Vec::new();
@@ -434,9 +434,9 @@ impl Tracker {
         let update = &mut |chunk_index, expected_fprint| -> Result<bool> {
             num_snapshotted += 1;
 
-            let begin = chunk_index * SNAPSHOT_GRANULARITY;
-            let end = if (len - begin) > SNAPSHOT_GRANULARITY {
-                begin + SNAPSHOT_GRANULARITY
+            let begin = chunk_index * WRITE_SNAPSHOT_GRANULARITY;
+            let end = if (len - begin) > WRITE_SNAPSHOT_GRANULARITY {
+                begin + WRITE_SNAPSHOT_GRANULARITY
             } else {
                 len
             };
@@ -483,7 +483,7 @@ impl Tracker {
         };
 
         for (base, expected_fprint) in &self.dirty_chunks {
-            let chunk_index = base / SNAPSHOT_GRANULARITY;
+            let chunk_index = base / WRITE_SNAPSHOT_GRANULARITY;
 
             // Everything greater than or equal to `backfill_begin`
             // will be handled by the loop below.  This avoids
@@ -514,7 +514,7 @@ impl Tracker {
             if cfg!(not(feature = "test_vfs"))
                 && !self
                     .dirty_chunks
-                    .contains_key(&(random_index * SNAPSHOT_GRANULARITY))
+                    .contains_key(&(random_index * WRITE_SNAPSHOT_GRANULARITY))
             {
                 // We don't *have* to get these additional chunks, so
                 // we don't want to bubble up errors.
@@ -615,6 +615,7 @@ impl Tracker {
                 generated_by: crate::manifest_schema::generator_version_bytes(),
                 chunks: compressible,
                 bundled_chunks,
+                base_chunk_size: None,
             }),
         };
 

--- a/src/unzstd.rs
+++ b/src/unzstd.rs
@@ -7,8 +7,10 @@ const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
 /// How big to set the initial capacity by default.
 ///
 /// We expect to mostly decompress chunks of this size.
-const BOUNDED_VECTOR_SIZE_INITIAL_CAPACITY: usize =
-    crate::tracker::WRITE_SNAPSHOT_GRANULARITY as usize;
+fn bounded_vector_size_initial_capacity() -> usize {
+    crate::tracker::DEFAULT_WRITE_SNAPSHOT_GRANULARITY
+        .max(crate::tracker::write_snapshot_granularity()) as usize
+}
 
 /// A `Writer` that dumps bytes to `dst` and fails instead of writing
 /// more than `max` bytes.
@@ -27,7 +29,7 @@ impl BoundedVectorSink {
     fn new(max: usize) -> Self {
         Self {
             dst: Some(Vec::with_capacity(
-                max.clamp(0, BOUNDED_VECTOR_SIZE_INITIAL_CAPACITY),
+                max.clamp(0, bounded_vector_size_initial_capacity()),
             )),
             max,
         }

--- a/src/unzstd.rs
+++ b/src/unzstd.rs
@@ -7,7 +7,8 @@ const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
 /// How big to set the initial capacity by default.
 ///
 /// We expect to mostly decompress chunks of this size.
-const BOUNDED_VECTOR_SIZE_INITIAL_CAPACITY: usize = crate::tracker::SNAPSHOT_GRANULARITY as usize;
+const BOUNDED_VECTOR_SIZE_INITIAL_CAPACITY: usize =
+    crate::tracker::WRITE_SNAPSHOT_GRANULARITY as usize;
 
 /// A `Writer` that dumps bytes to `dst` and fails instead of writing
 /// more than `max` bytes.


### PR DESCRIPTION
The first two commits are small cleanups.

The next commit adds an optional `base_chunk_size` field in the ManifestV1 proto. When this new field is populated, it holds the base chunk size for the chunks referenced by that manifest: all but the last chunk must have that size (the final chunk may be smaller). This new proto field has the unused protobuf index 10.

Given this infrastructure, it's easy to make the writer's chunk size configurable (with an environment variable for now), and to pipe that to the manifest.

Tested with `t/test.sh` (i.e., large chunks of the sqlite test suite with validation of the replicated data).